### PR TITLE
fix(ble): negotiate ATVV audio and separate HID reports

### DIFF
--- a/src/ble/ble_remote_client.cpp
+++ b/src/ble/ble_remote_client.cpp
@@ -42,7 +42,11 @@ static NimBLEAdvertisedDevice*         s_pending_adv_device = nullptr;
 static String                          s_pending_mac = "";
 static uint8_t                         s_pending_addr_type = BLE_ADDR_RANDOM;
 
-static uint8_t                         s_session_id = 0;
+static bool                           s_voice_ready = false;
+static uint16_t                       s_atvv_version = 0;
+// Defer GATT writes until the BLE task, outside notification callbacks.
+static volatile int                   s_mic_request = 0;
+static uint8_t                        s_session_id = 0;
 static uint32_t                        s_last_audio_ms = 0;
 static uint32_t                        s_last_extend_ms = 0;
 static uint32_t                        s_last_scan_ms = 0;
@@ -59,7 +63,7 @@ static bool setup_services_and_handshake();
 
 // Audio Notification Callback (ATVV Char 0x03)
 static void on_audio_notify(NimBLERemoteCharacteristic* pChar, uint8_t* pData, size_t length, bool isNotify) {
-    if (length == 0) return;
+    if (length == 0 || !s_voice_ready || length > AUDIO_DEFAULT_FRAME_SAMPS) return;
     s_last_audio_ms = millis();
     audio_pipeline_feed_adpcm(&g_audio_pipeline, pData, length);
 }
@@ -69,18 +73,22 @@ static void on_ctl_notify(NimBLERemoteCharacteristic* pChar, uint8_t* pData, siz
     if (length < 1) return;
     uint8_t op = pData[0];
 
-    // AUDIO_START with HTT reason: byte1 == 0x03
-    if (op == 0x04 && length >= 2 && pData[1] == 0x03) {
+    // AUDIO_START confirms the remote opened the negotiated stream.
+    if (op == 0x04 && length >= 2) {
         s_session_id = (length >= 4) ? pData[3] : 0;
         s_ble_state = BLE_STATE_TALKING;
         s_last_audio_ms = millis();
         s_last_extend_ms = millis();
 
-        key_engine_feed_key(&g_key_engine, MI_KEY_VOICE, true, millis());
+        audio_pipeline_start_session(&g_audio_pipeline, s_session_id);
         app_log("ATVV", ">>> Voice button PRESSED (session %d)", s_session_id);
     }
-    // AUDIO_STOP / MIC_CLOSED / release op (0x00 or 0x08):
-    else if (op == 0x00 || op == 0x08) {
+    // MIC_BUTTON requests microphone activation; it is not AUDIO_STOP.
+    else if (op == 0x08) {
+        if (s_voice_ready) s_mic_request = 1;
+    }
+    else if (op == 0x00) {
+        audio_pipeline_stop_session(&g_audio_pipeline);
         if (s_ble_state == BLE_STATE_TALKING) {
             s_ble_state = BLE_STATE_CONNECTED;
             key_engine_feed_key(&g_key_engine, MI_KEY_VOICE, false, millis());
@@ -93,6 +101,11 @@ static void on_ctl_notify(NimBLERemoteCharacteristic* pChar, uint8_t* pData, siz
     // CAPS_RESP: op == 0x0B
     else if (op == 0x0B && length >= 7) {
         uint16_t ver = (pData[1] << 8) | pData[2];
+        s_atvv_version = ver;
+        uint8_t codecs = ver >= 0x0100 ? pData[3] : (length >= 9 ? pData[4] : 0);
+        if (codecs == 0 && length >= 9) codecs = pData[4];
+        s_voice_ready = (codecs & 0x02) != 0;
+        app_log("ATVV", "Capabilities accepted: voice_ready=%d", s_voice_ready);
         uint16_t fs = (pData[5] << 8) | pData[6];
         if (fs > 0) s_frame_size = fs;
         app_log("ATVV", "CAPS: ver=0x%04X, frame_size=%d", ver, (int)s_frame_size);
@@ -112,11 +125,11 @@ static uint8_t s_last_hogp_key = 0;
 static void on_hogp_report_notify(NimBLERemoteCharacteristic* pChar, uint8_t* pData, size_t length, bool isNotify) {
     if (length < 1) return;
 
-    // 1. Audio / Voice Packets (len > 8, e.g. 20, 120, 240 bytes ADPCM)
+    // HID payloads are not ATVV ADPCM. Never feed them to that decoder.
     if (length > 8) {
-        app_log("HOGP_AUD", "Voice frame len=%d from Char %s", (int)length, pChar->getUUID().toString().c_str());
-        s_last_audio_ms = millis();
-        audio_pipeline_feed_adpcm(&g_audio_pipeline, pData, length);
+        static uint32_t ignored = 0;
+        if ((ignored++ % 128) == 0)
+            app_log("HID_AUDIO", "Ignoring non-ATVV report handle=%u len=%u", pChar->getHandle(), (unsigned)length);
         return;
     }
 
@@ -191,11 +204,7 @@ static void on_hogp_report_notify(NimBLERemoteCharacteristic* pChar, uint8_t* pD
         app_log("HOGP", "Key event: 0x%02X (%s)", raw_key, is_pressed ? "DOWN" : "UP");
         if (raw_key == MI_KEY_VOICE || raw_key == MI_KEY_VOICE_ALT) {
             app_log("VOICE", "Voice button event: 0x%02X (%s)", raw_key, is_pressed ? "DOWN" : "UP");
-            if (s_char_cmd != nullptr && is_pressed) {
-                uint8_t cmd_open[] = { 0x0C, 0x00 };
-                s_char_cmd->writeValue(cmd_open, sizeof(cmd_open), false);
-                app_log("ATVV", "Triggered MIC_OPEN on Voice key press");
-            }
+            if (s_voice_ready) s_mic_request = is_pressed ? 1 : -1;
         }
         key_engine_feed_key(&g_key_engine, raw_key, is_pressed, millis());
     }
@@ -322,6 +331,8 @@ class ClientCallbacks : public NimBLEClientCallbacks {
         app_log("BLE", "Remote Disconnected (lastErr: %d, %s)", err, NimBLEUtils::returnCodeToString(err));
         s_ble_state = BLE_STATE_DISCONNECTED;
         s_do_connect = false;
+        s_voice_ready = false;
+        s_mic_request = 0;
         s_char_cmd = nullptr;
         s_char_aud = nullptr;
         s_char_ctl = nullptr;
@@ -375,103 +386,55 @@ static bool setup_services_and_handshake() {
     }
     vTaskDelay(pdMS_TO_TICKS(50));
 
-    // 2. Discover services
-    std::vector<NimBLERemoteService*>* pServices = s_client->getServices(true);
-    if (!pServices) {
-        app_log("BLE", "No GATT services found");
+    s_voice_ready = false;
+    s_atvv_version = 0;
+    s_char_cmd = s_char_ctl = s_char_aud = nullptr;
+    auto* voice = s_client->getService(NimBLEUUID(ATVV_SVC_UUID));
+    if (voice) {
+        s_char_cmd = voice->getCharacteristic(NimBLEUUID(ATVV_CHAR_CMD_UUID));
+        s_char_ctl = voice->getCharacteristic(NimBLEUUID(ATVV_CHAR_CTL_UUID));
+        s_char_aud = voice->getCharacteristic(NimBLEUUID(ATVV_CHAR_AUD_UUID));
+    }
+    bool subscriptions = false;
+    if (s_char_cmd && s_char_ctl && s_char_aud) {
+        bool ctl = s_char_ctl->subscribe(true, on_ctl_notify, true);
+        bool aud = ctl && s_char_aud->subscribe(true, on_audio_notify, true);
+        subscriptions = ctl && aud;
+        app_log("ATVV", "Subscriptions: control=%d audio=%d", ctl, aud);
+        if (subscriptions) {
+            uint8_t caps[] = {0x0A, 0x01, 0x00, 0x00, 0x03, 0x03};
+            bool sent = s_char_cmd->writeValue(caps, sizeof(caps), true);
+            app_log("ATVV", "Capability query sent=%d", sent);
+            for (int i = 0; sent && !s_voice_ready && s_client->isConnected() && i < 40; ++i)
+                vTaskDelay(pdMS_TO_TICKS(50));
+        }
+    } else {
+        app_log("ATVV", "Missing characteristic: cmd=%d ctl=%d aud=%d",
+                s_char_cmd != nullptr, s_char_ctl != nullptr, s_char_aud != nullptr);
+    }
+
+    // Subscribe only input reports, after the private voice service is ready.
+    if (s_client->isConnected()) {
+        auto* hid = s_client->getService(NimBLEUUID((uint16_t)0x1812));
+        if (hid) {
+            auto* chars = hid->getCharacteristics(true);
+            if (chars) for (auto* chr : *chars) {
+                if (chr->getUUID().equals(NimBLEUUID((uint16_t)0x2a4d)) && chr->canNotify()) {
+                    bool ok = chr->subscribe(true, on_hogp_report_notify, true);
+                    app_log("HOGP", "Input handle=%u subscribed=%d", chr->getHandle(), ok);
+                }
+            }
+        }
+    }
+    if (!s_client->isConnected()) {
+        s_voice_ready = false;
+        s_ble_state = BLE_STATE_DISCONNECTED;
+        app_log("BLE", "Setup interrupted by disconnect; will rescan");
         return false;
     }
-
-    app_log("BLE", "Discovered %d GATT Service(s)", (int)pServices->size());
-
-    int sub_count = 0;
-    for (auto* pSvc : *pServices) {
-        String svc_uuid = pSvc->getUUID().toString().c_str();
-        svc_uuid.toLowerCase();
-        app_log("GATT_SVC", "Service: %s", svc_uuid.c_str());
-
-        // Skip known standard BLE metadata services (0x1800 GAP, 0x1801 GATT, 0x180A DIS, 0x180F Battery)
-        if (svc_uuid.indexOf("1800") >= 0 || svc_uuid.indexOf("1801") >= 0 || 
-            svc_uuid.indexOf("180a") >= 0 || svc_uuid.indexOf("180f") >= 0) {
-            continue;
-        }
-
-        std::vector<NimBLERemoteCharacteristic*>* pChars = pSvc->getCharacteristics(true);
-        if (!pChars) continue;
-
-        for (auto* pChar : *pChars) {
-            String char_uuid = pChar->getUUID().toString().c_str();
-            char_uuid.toLowerCase();
-            bool can_notif = pChar->canNotify();
-            bool can_ind = pChar->canIndicate();
-            bool can_wr = pChar->canWrite() || pChar->canWriteNoResponse();
-            app_log("GATT_CHAR", "  Char: %s (N:%d, I:%d, W:%d)", char_uuid.c_str(), can_notif ? 1 : 0, can_ind ? 1 : 0, can_wr ? 1 : 0);
-
-            // Match ATVV CMD (ab5e0002)
-            if (char_uuid.indexOf("ab5e0002") >= 0) {
-                s_char_cmd = pChar;
-                app_log("ATVV", "Matched ATVV CMD Char: %s", char_uuid.c_str());
-            }
-            // Match ATVV AUD (ab5e0003)
-            else if (char_uuid.indexOf("ab5e0003") >= 0) {
-                s_char_aud = pChar;
-                if (can_notif) {
-                    pChar->subscribe(true, on_audio_notify, false);
-                    sub_count++;
-                    app_log("ATVV", "Subscribed to ATVV AUD Char: %s", char_uuid.c_str());
-                }
-            }
-            // Match ATVV CTL (ab5e0004)
-            else if (char_uuid.indexOf("ab5e0004") >= 0) {
-                s_char_ctl = pChar;
-                if (can_notif) {
-                    pChar->subscribe(true, on_ctl_notify, false);
-                    sub_count++;
-                    app_log("ATVV", "Subscribed to ATVV CTL Char: %s", char_uuid.c_str());
-                }
-            }
-            // Match Protocol Mode (0x2A4E) -> write Report Mode (0x01)
-            else if (char_uuid.indexOf("2a4e") >= 0) {
-                if (can_wr) {
-                    uint8_t mode = 0x01;
-                    pChar->writeValue(&mode, 1, false);
-                    app_log("HOGP", "Set Protocol Mode to Report Mode (0x01)");
-                }
-            }
-            // Match HID Control Point (0x2A4C) -> write Exit Suspend (0x00)
-            else if (char_uuid.indexOf("2a4c") >= 0) {
-                if (can_wr) {
-                    uint8_t cp = 0x00;
-                    pChar->writeValue(&cp, 1, false);
-                }
-            }
-            // Match HOGP Report (0x2A4D) or any notify char in 0x1812 service
-            else if (char_uuid.indexOf("2a4d") >= 0 || svc_uuid.indexOf("1812") >= 0) {
-                if (can_notif || can_ind) {
-                    pChar->subscribe(true, on_hogp_report_notify, false);
-                    sub_count++;
-                    app_log("HOGP", "Subscribed to Report Char: %s", char_uuid.c_str());
-                }
-            }
-        }
-    }
-
-    app_log("BLE", "Total Subscribed Characteristic(s): %d", sub_count);
-
-    // 3. Negotiate data length and connection parameters
-    s_client->setDataLen(251);
-    s_client->updateConnParams(12, 12, 0, 400);
-
-    // 4. ATVV Handshake: query CAPS capability only. Do NOT force mic open at boot.
-    if (s_char_cmd) {
-        uint8_t cmd_caps[] = { 0x0A, 0x01, 0x00, 0x00, 0x03, 0x03 };
-        s_char_cmd->writeValue(cmd_caps, sizeof(cmd_caps), false);
-        app_log("ATVV", "Handshake: GET_CAPS query sent (Mic remains in low-power standby)");
-    }
-
     s_ble_state = BLE_STATE_CONNECTED;
     led_indicator_set(LED_STATE_CONNECTED);
-    s_last_keepalive_ms = millis();
+    app_log("BLE", "Connected, ATVV voice_ready=%d", s_voice_ready);
     return true;
 }
 
@@ -606,6 +569,15 @@ void ble_remote_init(void) {
 
 void ble_remote_task(void) {
     uint32_t now = millis();
+    int request = s_mic_request;
+    if (request && s_client && s_client->isConnected() && s_char_cmd && s_voice_ready) {
+        s_mic_request = 0;
+        uint8_t cmd[3] = {request > 0 ? (uint8_t)0x0C : (uint8_t)0x0D, 0, 0};
+        size_t len = request > 0 ? (s_atvv_version >= 0x0100 ? 2 : 3) : (s_atvv_version >= 0x0100 ? 2 : 1);
+        if (request < 0) cmd[1] = s_session_id;
+        bool sent = s_char_cmd->writeValue(cmd, len, true);
+        app_log("ATVV", "Mic %s sent=%d", request > 0 ? "open" : "close", sent);
+    }
 
     // 1. Process asynchronous unpair / reconnect requests from Core 1
     if (s_req_unpair || s_req_reconnect) {
@@ -750,6 +722,10 @@ String ble_remote_get_connected_info(void) {
     String out;
     serializeJson(doc, out);
     return out;
+}
+
+bool ble_remote_voice_ready(void) {
+    return s_voice_ready;
 }
 
 } // extern "C"

--- a/src/ble/ble_remote_client.h
+++ b/src/ble/ble_remote_client.h
@@ -32,6 +32,8 @@ void ble_remote_task(void);
  * @brief Get current BLE connection state
  */
 ble_remote_state_t ble_remote_get_state(void);
+/** @brief Whether the connected remote advertised a supported ATVV codec. */
+bool ble_remote_voice_ready(void);
 
 /**
  * @brief Trigger manual reconnect / re-scan

--- a/src/cli/cli_manager.cpp
+++ b/src/cli/cli_manager.cpp
@@ -22,6 +22,7 @@ static void handle_command(const String& line) {
         doc["target"] = HARDWARE_TARGET;
         doc["uptime_sec"] = millis() / 1000;
         doc["ble_state"] = (int)ble_remote_get_state();
+        doc["voice_ready"] = ble_remote_voice_ready();
         doc["frames_decoded"] = g_audio_pipeline.total_frames_decoded;
         doc["samples_pushed"] = g_audio_pipeline.total_samples_pushed;
         doc["free_heap"] = ESP.getFreeHeap();


### PR DESCRIPTION
## Problem

On an ESP32-S3 N16R8 with a Xiaomi RC003 remote, USB recording contained only a short initial transient followed by near silence. Long HID reports were passed to the IMA ADPCM decoder solely because of their length, even though the observed 60-byte HID payloads had an H2/mSBC-style header. Rebuilding the original firmware did not fix the recording.

## Changes

- Discover the exact ATVV service and its command/control/audio characteristics before subscribing to HID input reports. Check subscription results and wait for the capability response.
- Expose `voice_ready` in CLI status and admit ATVV audio only after a supported codec is reported. Ignore long HID payloads instead of decoding them as ATVV ADPCM; this does not add an mSBC decoder.
- Treat control opcode `0x08` as a microphone activation request, not a stop event. Start/reset the audio session on AUDIO_START and stop it on AUDIO_STOP.
- Defer microphone commands from notification callbacks to the BLE task, send version-dependent open/close payloads, and request close on voice-key release.
- Preserve HID key subscriptions and return to disconnected state if service setup loses its connection.

## Validation

- Built the cleaned patch for `esp32s3_n16r8` using PlatformIO 6.1.19, Espressif32 7.1.2, Arduino framework package 4.20017.260907, and NimBLE-Arduino 1.4.3. These dependency selections were local build overrides, not changes to the repository configuration.
- Hardware-tested the functional fix with additional temporary PCM diagnostics on ESP32-S3, 16 MB flash / 8 MB PSRAM, and one Xiaomi RC003 remote. Those diagnostics are excluded from this patch.
- ATVV control/audio subscriptions both succeeded; the remote returned version `0x0100` and a 120-byte frame size.
- A held voice-key recording produced 246 ATVV frames / 59,040 samples and about three seconds of audible speech, followed by silence after release. The user listened to the recording and confirmed the improvement.
- Volume up/down and back produced both press and release events in the hardware test. No Windows global keyboard hook is added.

Other remote models, legacy ATVV versions, and prolonged reconnect/soak behavior still need hardware validation. This patch does not attempt to fix unrelated USB readiness/reset warnings.
